### PR TITLE
WIP: Tree Prefixes are (very!) possible in Haskell

### DIFF
--- a/generics-mrsop.cabal
+++ b/generics-mrsop.cabal
@@ -1,5 +1,5 @@
 name:                generics-mrsop
-version:             1.1.0
+version:             1.1.1
 
 synopsis:            Generic Programming with Mutually Recursive Sums of Products.
 
@@ -39,6 +39,7 @@ library
     Generics.MRSOP.Util,
     Generics.MRSOP.TH,
     Generics.MRSOP.Zipper,
+    Generics.MRSOP.Treefix,
     Generics.MRSOP.Examples.RoseTree,
     Generics.MRSOP.Examples.RoseTreeTH,
     Generics.MRSOP.Examples.LambdaAlphaEqTH,

--- a/src/Generics/MRSOP/Treefix.hs
+++ b/src/Generics/MRSOP/Treefix.hs
@@ -17,38 +17,48 @@ import Data.Type.Equality
 import Generics.MRSOP.Util hiding (Cons , Nil)
 import Generics.MRSOP.Base
 
+{-
 -- |In a @Zipper@, a Location is a a pair of a one hole context
 --  and whatever was supposed to be there. In a sums of products
 --  fashion, it consists of a choice of constructor and
 --  a position in the type of that constructor.
 data Loc :: (kon -> *) -> [*] -> [[[Atom kon]]] -> Nat -> * where
-  Loc :: IsNat ix => El fam ix -> Ctxs ki fam cs iy ix -> Loc ki fam cs iy
+  Loc :: All IsNat ixs => NP (El fam) ixs -> Ctxs ki fam cs iy ixs -> Loc ki fam cs iy
+-}
 
 -- |A @Ctxs ki fam codes ix iy@ represents a value of type @El fam ix@
 --  with a @El fam iy@-typed hole in it.
 data Ctxs :: (kon -> *) -> [*] -> [[[Atom kon]]] -> Nat -> Nat -> * where
   Nil  :: Ctxs ki fam cs ix ix
-  Cons :: (IsNat ix , IsNat a , IsNat b)
-       => Ctx ki fam (Lkup ix cs) b -> Ctxs ki fam cs a ix
-       -> Ctxs ki fam cs a b
+  Cons :: (IsNat ixs , All IsNat bs , IsNat a)
+       => Ctx ki fam (Lkup ix cs) bs -> Ctxs ki fam cs a ixs
+       -> Ctxs ki fam cs a bs
 
 -- |A @Ctx ki fam c ix@ is a choice of constructor for @c@
 --  with a hole of type @ix@ inside.
-data Ctx :: (kon -> *) -> [*] -> [[Atom kon]] -> Nat -> * where
+data Ctx :: (kon -> *) -> [*] -> [[Atom kon]] -> [Nat] -> * where
   Ctx :: Constr c n
-      -> NPHole ki fam ix (Lkup n c)
-      -> Ctx ki fam c ix
+      -> NPHole ki fam ixs (Lkup n c)
+      -> Ctx ki fam c ixs
 
 -- |A @NPHole ki fam ix prod@ is a recursive position
 --  of type @ix@ in @prod@.
-data NPHole :: (kon -> *) -> [*] -> Nat -> [Atom kon] -> * where
-  H :: PoA ki (El fam) xs -> NPHole ki fam ix (I ix : xs)
-  T :: NA ki (El fam) x -> NPHole ki fam ix xs -> NPHole ki fam ix (x : xs)
+data NPHole :: (kon -> *) -> [*] -> [Nat] -> [Atom kon] -> * where
+  -- |Last hole
+  H0 :: PoA ki (El fam) xs    -> NPHole ki fam (ix : '[]) (I ix : xs)
+  -- |Not-the-last hole
+  H1 :: NPHole ki fam ixs xs  -> NPHole ki fam (ix : ixs) (I ix : xs)
+  -- |Not a hole
+  T  :: NA ki (El fam) x      -> NPHole ki fam ixs xs -> NPHole ki fam ixs (x : xs)
 
+{-
 -- |Existential abstraction; needed for walking the possible
 --  holes in a product. We must be able to hide the type.
 data NPHoleE :: (kon -> *) -> [*] -> [Atom kon] -> * where
   ExistsIX :: IsNat ix => El fam ix -> NPHole ki fam ix xs -> NPHoleE ki fam xs
+-}
+
+{-
 
 -- |Given a 'PoA' (product of atoms), returns a one with a hole
 --  in the first seen 'NA_I'. Note that we need the 'NPHoleE'
@@ -137,3 +147,5 @@ update :: (Family ki fam codes , IsNat ix)
        => (forall ix . SNat ix -> El fam ix -> El fam ix)
        -> Loc ki fam codes ix -> Loc ki fam codes ix
 update f (Loc el ctxs) = Loc (f (getElSNat el) el) ctxs
+
+-}

--- a/src/Generics/MRSOP/Treefix.hs
+++ b/src/Generics/MRSOP/Treefix.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE FlexibleContexts     #-}
@@ -66,9 +67,15 @@ data Way :: [[[Atom kon]]] -> Atom kon -> Type where
          -> NS (Way codes) (Lkup ctr (Lkup i codes))
          -> Way codes (I i)
 
-catWay :: Way codes a -> Way codes b -> Way codes a
-catWay HoleW w2 = w2
-catWay (Follow c ns) w2 = Follow c (mapNS (\w -> _) ns)
+instance Show (Way codes a) where
+  show HoleW = "HoleW"
+  show (Follow c ns)
+    = let (n , str) = go ns
+       in show c ++ "{" ++ show n ++ "}(" ++ str ++ ")"
+    where
+      go :: NS (Way codes) s -> (Int , String)
+      go (Here x) = (0 , show x)
+      go (There y) = (1+) *** id $ go y
 
 data PathE :: [[[Atom kon]]] -> Nat -> Type where
   PathE :: Path codes (I i) p -> PathE codes i

--- a/src/Generics/MRSOP/Treefix.hs
+++ b/src/Generics/MRSOP/Treefix.hs
@@ -24,7 +24,6 @@ data Paths
   | End
   | Under [Paths]
 
-type family Merge (px :: Paths) (py :: Paths) :: Paths where
 
 data Way :: [[[Atom kon]]] -> Nat -> Paths -> * where
   WayHere  :: Way codes ix Hole
@@ -80,6 +79,14 @@ data TxNP :: (kon -> *) -> [*] -> [[[Atom kon]]] -> [Atom kon] -> [Paths] -> *
   TxNPSolid :: NA ki (El fam) at
             -> TxNP ki fam codes prod yss
             -> TxNP ki fam codes (at ': prod) (End ': yss)
+
+type family (px :: Paths) :&: (py :: Paths) :: Paths where
+
+walkTo :: Way codes i path'
+       -> Tx ki fam codes i path
+       -> Maybe (Tx ki fam codes i (path :&: path'))
+walkTo WayHere tx            = _
+walkTo (WayThere c wayNP) tx = _
 
 {-
 

--- a/src/Generics/MRSOP/Treefix.hs
+++ b/src/Generics/MRSOP/Treefix.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE RankNTypes           #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
@@ -8,144 +9,62 @@
 {-# LANGUAGE PolyKinds            #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TypeApplications     #-}
--- |Provides Zippers (aka One-hole contexts) for our
---  universe.
-module Generics.MRSOP.Zipper where
+-- |Provides the notion of typed tree-prefix
+--  for out universe.
+module Generics.MRSOP.Treefix where
 
 import Data.Type.Equality
 
 import Generics.MRSOP.Util hiding (Cons , Nil)
 import Generics.MRSOP.Base
 
-{-
--- |In a @Zipper@, a Location is a a pair of a one hole context
---  and whatever was supposed to be there. In a sums of products
---  fashion, it consists of a choice of constructor and
---  a position in the type of that constructor.
-data Loc :: (kon -> *) -> [*] -> [[[Atom kon]]] -> Nat -> * where
-  Loc :: All IsNat ixs => NP (El fam) ixs -> Ctxs ki fam cs iy ixs -> Loc ki fam cs iy
--}
+-- |A Tree-prefix @Tx ki fam codes i js@ specifies a path that ultimately
+--  leats to @length js@ trees of the respective types inside an element
+--  of type @El fam i@. In a dependently typed language, one would use
+--  a notion of /subsequence/ and write a slightly more elegant version.
+data Tx :: (kon -> *) -> [*] -> [[[Atom kon]]] -> Nat -> [Nat] -> * where
+  -- |Marks the end of a path. As soon as a path ends, there is only
+  --  one possible subtree it can mark.
+  TxHere :: Tx ki fam codes i (i ': '[])
+  -- |Marks the forking of a path by specifying a constructor
+  --  and a selection of the elements of this constructor's fields
+  --  to continue.
+  TxPeel :: Constr (Lkup i codes) n
+         -> TxNP ki fam codes (Lkup n (Lkup i codes)) ys
+         -> Tx ki fam codes i ys
 
--- |A @Ctxs ki fam codes ix iy@ represents a value of type @El fam ix@
---  with a @El fam iy@-typed hole in it.
-data Ctxs :: (kon -> *) -> [*] -> [[[Atom kon]]] -> Nat -> Nat -> * where
-  Nil  :: Ctxs ki fam cs ix ix
-  Cons :: (IsNat ixs , All IsNat bs , IsNat a)
-       => Ctx ki fam (Lkup ix cs) bs -> Ctxs ki fam cs a ixs
-       -> Ctxs ki fam cs a bs
+-- |A Tree-prefix over a product; a value pf type @TxNP ki fam codes prod js@
+--  marks @length js@ subtrees of the corresponding type within a
+--  product-of-atoms ('PoA') @PoA ki (El fam) prod@.
+--
+--  We employ several Haskell hacks here. Most notably, this datatype is
+--  'fused' with a proof that 'map I js' is a subsequence of 'prod'
+--
+data TxNP :: (kon -> *) -> [*] -> [[[Atom kon]]] -> [Atom kon] -> [Nat] -> *
+    where
+  TxNPNil   :: TxNP ki fam codes '[] '[]
+  TxNPPath  :: Tx ki fam codes i ys
+            -> TxNP ki fam codes prod yss
+            -> TxNP ki fam codes (I i ': prod) (ys :++: yss)
+  TxNPSolid :: NA ki (El fam) at
+            -> TxNP ki fam codes prod yss
+            -> TxNP ki fam codes (at ': prod) yss
 
--- |A @Ctx ki fam c ix@ is a choice of constructor for @c@
---  with a hole of type @ix@ inside.
-data Ctx :: (kon -> *) -> [*] -> [[Atom kon]] -> [Nat] -> * where
-  Ctx :: Constr c n
-      -> NPHole ki fam ixs (Lkup n c)
-      -> Ctx ki fam c ixs
+-- |Given a treefix ('Tx') and an element, try to return all the
+--  subtrees in the specified paths.
+select :: (Family ki fam codes , Eq1 ki , Eq1 (El fam))
+       => Tx ki fam codes ix iys -> El fam ix -> Maybe (NP (El fam) iys)
+select TxHere          x = Just (x :* NP0)
+select (TxPeel c txnp) x = match c (sfrom x) >>= selectNP txnp 
 
--- |A @NPHole ki fam ix prod@ is a recursive position
---  of type @ix@ in @prod@.
-data NPHole :: (kon -> *) -> [*] -> [Nat] -> [Atom kon] -> * where
-  -- |Last hole
-  H0 :: PoA ki (El fam) xs    -> NPHole ki fam (ix : '[]) (I ix : xs)
-  -- |Not-the-last hole
-  H1 :: NPHole ki fam ixs xs  -> NPHole ki fam (ix : ixs) (I ix : xs)
-  -- |Not a hole
-  T  :: NA ki (El fam) x      -> NPHole ki fam ixs xs -> NPHole ki fam ixs (x : xs)
-
-{-
--- |Existential abstraction; needed for walking the possible
---  holes in a product. We must be able to hide the type.
-data NPHoleE :: (kon -> *) -> [*] -> [Atom kon] -> * where
-  ExistsIX :: IsNat ix => El fam ix -> NPHole ki fam ix xs -> NPHoleE ki fam xs
--}
-
-{-
-
--- |Given a 'PoA' (product of atoms), returns a one with a hole
---  in the first seen 'NA_I'. Note that we need the 'NPHoleE'
---  with the existential because we don't know, a priori, what
---  will be the type of such hole.
-mkNPHole :: PoA ki (El fam) xs -> Maybe (NPHoleE ki fam xs)
-mkNPHole NP0 = Nothing
-mkNPHole (NA_I x :* xs) = Just (ExistsIX x (H xs))
-mkNPHole (NA_K k :* xs)
-  = do (ExistsIX el c) <- mkNPHole xs
-       return (ExistsIX el (T (NA_K k) c))
-
--- |Given a hole and an element, put both together to form
---  the 'PoA' again.
-fillNPHole :: (IsNat ix) => El fam ix -> NPHole ki fam ix xs -> PoA ki (El fam) xs
-fillNPHole x (H xs)   = NA_I x :* xs
-fillNPHole x (T y xs) = y :* fillNPHole x xs
-
--- |Given an hole and an element, return the next hole, if any.
-walkNPHole :: (IsNat ix) => El fam ix -> NPHole ki fam ix xs -> Maybe (NPHoleE ki fam xs)
-walkNPHole el (H xs)
-  = do (ExistsIX el' c) <- mkNPHole xs
-       return (ExistsIX el' (T (NA_I el) c))
-walkNPHole el (T na xs)
-  = do (ExistsIX el' c) <- walkNPHole el xs
-       return (ExistsIX el' (T na c))
-
--- * Primitives
-
--- |Executes an action in the first hole within the given 'Rep' value,
---  if such hole can be constructed.
-first :: (forall ix . IsNat ix => El fam ix -> Ctx ki fam c ix -> a)
-      -> Rep ki (El fam) c -> Maybe a
-first f el | Tag c p <- sop el
-  = do (ExistsIX el nphole) <- mkNPHole p
-       return (f el (Ctx c nphole))
-
--- |Fills up a hole.
-fill :: (IsNat ix) => El fam ix -> Ctx ki fam c ix -> Rep ki (El fam) c
-fill el (Ctx c nphole) = inj c (fillNPHole el nphole)
-
--- |Walks to the next hole and execute an action.
-next :: (IsNat ix)
-     => (forall iy . IsNat iy => El fam iy -> Ctx ki fam c iy -> a)
-     -> El fam ix -> Ctx ki fam c ix -> Maybe a
-next f el (Ctx c nphole)
-  = do (ExistsIX el' nphole') <- walkNPHole el nphole
-       return (f el' (Ctx c nphole'))
-
--- * Navigation
-
--- |Move one layer deeper within the recursive structure.
-down :: (Family ki fam codes , IsNat ix)
-     => Loc ki fam codes ix -> Maybe (Loc ki fam codes ix)
-down (Loc el ctx)
-  = first (\el' ctx' -> Loc el' (Cons ctx' ctx))
-          (sfrom el)
-
--- |Move one layer upwards within the recursive structure
-up :: (Family ki fam codes, IsNat ix)
-   => Loc ki fam codes ix -> Maybe (Loc ki fam codes ix)
-up (Loc el Nil)             = Nothing
-up (Loc el (Cons ctx ctxs)) = Just (Loc (sto $ fill el ctx) ctxs)
-
--- |More one hole to the right
-right :: (Family ki fam codes, IsNat ix)
-      => Loc ki fam codes ix -> Maybe (Loc ki fam codes ix)
-right (Loc el Nil)             = Nothing
-right (Loc el (Cons ctx ctxs)) = next (\el' ctx' -> Loc el' (Cons ctx' ctxs)) el ctx
-
--- * Interface
-
--- |Initializes the zipper
-enter :: (Family ki fam codes , IsNat ix)
-      => El fam ix -> Loc ki fam codes ix
-enter el = Loc el Nil
-
--- |Exits the zipper
-leave :: (Family ki fam codes , IsNat ix)
-      => Loc ki fam codes ix -> El fam ix
-leave (Loc x Nil) = x
-leave loc         = maybe undefined leave $ up loc -- up returns a just!
-
--- |Updates the value in the hole.
-update :: (Family ki fam codes , IsNat ix)
-       => (forall ix . SNat ix -> El fam ix -> El fam ix)
-       -> Loc ki fam codes ix -> Loc ki fam codes ix
-update f (Loc el ctxs) = Loc (f (getElSNat el) el) ctxs
-
--}
+-- |Auxiliary function to 'select'
+selectNP :: (Family ki fam codes, Eq1 ki , Eq1 (El fam))
+         => TxNP ki fam codes prod iys
+         -> PoA ki (El fam) prod
+         -> Maybe (NP (El fam) iys)
+selectNP TxNPNil NP0 = Just NP0
+selectNP (TxNPSolid el txnp) (a :* poa)
+  | eqNA eq1 eq1 el a = selectNP txnp poa
+  | otherwise         = Nothing
+selectNP (TxNPPath  tx txnp) (NA_I a :* poa)
+  = appendNP <$> select tx a <*> selectNP txnp poa

--- a/src/Generics/MRSOP/Util.hs
+++ b/src/Generics/MRSOP/Util.hs
@@ -22,7 +22,7 @@ module Generics.MRSOP.Util
   , IsNat(..) , getNat , getSNat'
 
     -- * Type-level Lists
-  , ListPrf(..) , IsList(..)
+  , ListPrf(..) , IsList(..), All
   , L1 , L2 , L3 , L4
   , (:++:) , appendIsListLemma
 
@@ -34,6 +34,7 @@ module Generics.MRSOP.Util
   ) where
 
 import Data.Proxy
+import Data.Kind
 import Data.Type.Equality
 import GHC.TypeLits (TypeError , ErrorMessage(..))
 import Control.Arrow ((***) , (&&&))
@@ -149,6 +150,11 @@ appendIsListLemma (Cons isxs) isys = Cons (appendIsListLemma isxs isys)
 type family (:++:) (txs :: [k]) (tys :: [k]) :: [k] where
   (:++:) '[] tys = tys
   (:++:) (tx ': txs) tys = tx ': (txs :++: tys)
+
+-- |Constraining over type-level lists
+type family All (pred :: k -> Constraint) (l :: [k]) :: Constraint where
+  All pred '[]       = ()
+  All pred (x ': xs) = (pred x , All pred xs)
 
 -- |Convenient constraint synonyms
 type L1 xs          = (IsList xs) 

--- a/src/Generics/MRSOP/Util.hs
+++ b/src/Generics/MRSOP/Util.hs
@@ -20,6 +20,7 @@ module Generics.MRSOP.Util
   , Nat(..) , proxyUnsuc
   , SNat(..) , snat2int
   , IsNat(..) , getNat , getSNat'
+  , snat2Nat
 
     -- * Type-level Lists
   , ListPrf(..) , IsList(..), All
@@ -88,6 +89,10 @@ getNat = snat2int . getSNat
 
 getSNat' :: forall (n :: Nat). IsNat n => SNat n
 getSNat' = getSNat (Proxy :: Proxy n)
+
+snat2Nat :: SNat n -> Nat
+snat2Nat SZ     = Z
+snat2Nat (SS n) = S (snat2Nat n)
 
 instance TestEquality SNat where
   testEquality SZ     SZ     = Just Refl

--- a/src/Generics/MRSOP/Zipper.hs
+++ b/src/Generics/MRSOP/Zipper.hs
@@ -17,38 +17,48 @@ import Data.Type.Equality
 import Generics.MRSOP.Util hiding (Cons , Nil)
 import Generics.MRSOP.Base
 
+{-
 -- |In a @Zipper@, a Location is a a pair of a one hole context
 --  and whatever was supposed to be there. In a sums of products
 --  fashion, it consists of a choice of constructor and
 --  a position in the type of that constructor.
 data Loc :: (kon -> *) -> [*] -> [[[Atom kon]]] -> Nat -> * where
-  Loc :: IsNat ix => El fam ix -> Ctxs ki fam cs iy ix -> Loc ki fam cs iy
+  Loc :: All IsNat ixs => NP (El fam) ixs -> Ctxs ki fam cs iy ixs -> Loc ki fam cs iy
+-}
 
 -- |A @Ctxs ki fam codes ix iy@ represents a value of type @El fam ix@
 --  with a @El fam iy@-typed hole in it.
 data Ctxs :: (kon -> *) -> [*] -> [[[Atom kon]]] -> Nat -> Nat -> * where
   Nil  :: Ctxs ki fam cs ix ix
-  Cons :: (IsNat ix , IsNat a , IsNat b)
-       => Ctx ki fam (Lkup ix cs) b -> Ctxs ki fam cs a ix
-       -> Ctxs ki fam cs a b
+  Cons :: (IsNat ixs , All IsNat bs , IsNat a)
+       => Ctx ki fam (Lkup ix cs) bs -> Ctxs ki fam cs a ixs
+       -> Ctxs ki fam cs a bs
 
 -- |A @Ctx ki fam c ix@ is a choice of constructor for @c@
 --  with a hole of type @ix@ inside.
-data Ctx :: (kon -> *) -> [*] -> [[Atom kon]] -> Nat -> * where
+data Ctx :: (kon -> *) -> [*] -> [[Atom kon]] -> [Nat] -> * where
   Ctx :: Constr c n
-      -> NPHole ki fam ix (Lkup n c)
-      -> Ctx ki fam c ix
+      -> NPHole ki fam ixs (Lkup n c)
+      -> Ctx ki fam c ixs
 
 -- |A @NPHole ki fam ix prod@ is a recursive position
 --  of type @ix@ in @prod@.
-data NPHole :: (kon -> *) -> [*] -> Nat -> [Atom kon] -> * where
-  H :: PoA ki (El fam) xs -> NPHole ki fam ix (I ix : xs)
-  T :: NA ki (El fam) x -> NPHole ki fam ix xs -> NPHole ki fam ix (x : xs)
+data NPHole :: (kon -> *) -> [*] -> [Nat] -> [Atom kon] -> * where
+  -- |Last hole
+  H0 :: PoA ki (El fam) xs    -> NPHole ki fam (ix : '[]) (I ix : xs)
+  -- |Not-the-last hole
+  H1 :: NPHole ki fam ixs xs  -> NPHole ki fam (ix : ixs) (I ix : xs)
+  -- |Not a hole
+  T  :: NA ki (El fam) x      -> NPHole ki fam ixs xs -> NPHole ki fam ixs (x : xs)
 
+{-
 -- |Existential abstraction; needed for walking the possible
 --  holes in a product. We must be able to hide the type.
 data NPHoleE :: (kon -> *) -> [*] -> [Atom kon] -> * where
   ExistsIX :: IsNat ix => El fam ix -> NPHole ki fam ix xs -> NPHoleE ki fam xs
+-}
+
+{-
 
 -- |Given a 'PoA' (product of atoms), returns a one with a hole
 --  in the first seen 'NA_I'. Note that we need the 'NPHoleE'
@@ -137,3 +147,5 @@ update :: (Family ki fam codes , IsNat ix)
        => (forall ix . SNat ix -> El fam ix -> El fam ix)
        -> Loc ki fam codes ix -> Loc ki fam codes ix
 update f (Loc el ctxs) = Loc (f (getElSNat el) el) ctxs
+
+-}


### PR DESCRIPTION
Started playing around with our notion of multi-holed well-typed context; Called them `Treefix` in the
lights of "tree prefix". 

The definition in Haskell is surprisingly simple and seems to work. I'm opening up a PR to keep the discussion open for features and pay attention to compatibility with the rest of the lib. This is not supposed to be merged just yet.

Important files to check:
  - `Generics.MRSOP.Treefix`
  - `Generics.MRSOP.Examples.SimpTH`
