### PR TITLE
Candidate 2.3.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 # Revision history for generics-mrsop
 
+## 2.3.0 -- Oct 2019
+
+- Brought `EqHO` and `ShowHO` back. The quantified constraint fix (`forall x . Eq (f x)`)
+made for some complications on the user side that we were unhappy about.
+
 ## 2.2.0 -- Sep 2019
 
 - Brought in `NS` and `NP` from `sop-core` instead of defining it ourselfes.

--- a/generics-mrsop.cabal
+++ b/generics-mrsop.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6e4f3e6671cfaeff58301e7f3a59013225b8995b0e8cb2fbb43c1d48c1158cf0
+-- hash: 70539c4715fe3541bae476f1a318b450ec2afab772fca5e4d87aa41b9eab122a
 
 name:           generics-mrsop
-version:        2.2.0
+version:        2.3.0
 synopsis:       Generic Programming with Mutually Recursive Sums of Products.
 description:    A library that supports generic programming for mutually recursive families in the sum-of-products style. . A couple usage examples can be found under "Generics.MRSOP.Examples" .
 category:       Generics

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        generics-mrsop
-version:     2.2.0
+version:     2.3.0
 synopsis:    Generic Programming with Mutually Recursive Sums of Products.
 description:
   A library that supports generic programming for mutually

--- a/src/Generics/MRSOP/Base/NP.hs
+++ b/src/Generics/MRSOP/Base/NP.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE TypeOperators     #-}
 {-# LANGUAGE DataKinds         #-}
 {-# LANGUAGE PolyKinds         #-}
+{-# OPTIONS_GHC -Wno-orphans   #-}
 -- | Standard representation of n-ary products.
 module Generics.MRSOP.Base.NP
   ( SOP.NP(..)
@@ -25,6 +26,19 @@ module Generics.MRSOP.Base.NP
 import           Data.SOP.NP (NP(..))
 import qualified Data.SOP.NP as SOP
 import Generics.MRSOP.Util
+
+-- |@since 2.3.0
+instance EqHO f => EqHO (NP f) where
+  eqHO (x :* xs) (y :* ys) = eqHO x y && eqHO xs ys
+  eqHO Nil       Nil       = True
+
+-- |@since 2.3.0
+instance ShowHO f => ShowHO (NP f) where
+  showsPrecHO _ Nil = showString "Nil"
+  showsPrecHO d (x :* xs) = showParen (d > ifx_prec) $
+    showsPrecHO (ifx_prec+1) x . showString " :* " . showsPrecHO (ifx_prec+1) xs
+   where ifx_prec = 5
+
 
 -- * Relation to IsList predicate
 

--- a/src/Generics/MRSOP/Base/NS.hs
+++ b/src/Generics/MRSOP/Base/NS.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables         #-}
 {-# LANGUAGE ScopedTypeVariables         #-}
 {-# OPTIONS_GHC -Wno-name-shadowing      #-}
+{-# OPTIONS_GHC -Wno-orphans             #-}
 
 -- | Standard representation of n-ary sums.
 module Generics.MRSOP.Base.NS
@@ -41,6 +42,21 @@ pattern Here x = SOP.Z x
 
 {-# COMPLETE Here, There #-}
 
+-- |@since 2.3.0
+instance EqHO f => EqHO (NS f) where
+  eqHO (Here fx) (Here fy) = eqHO fx fy
+  eqHO (There x) (There y) = eqHO x y
+  eqHO _         _         = False
+
+-- |@since 2.3.0
+instance ShowHO f => ShowHO (NS f) where
+  showsPrecHO d (Here fx) = showParen (d > app_prec) $
+    showString "Here " . showsPrecHO (app_prec+1) fx
+   where app_prec = 10
+  showsPrecHO d (There fx) = showParen (d > app_prec) $
+    showString "There " . showsPrecHO (app_prec+1) fx
+   where app_prec = 10
+
 -- * Map, Zip and Elim
 
 -- |Maps over a sum
@@ -66,7 +82,6 @@ zipNS (There p) (There q) = There <$> zipNS p q
 zipNS _         _         = mzero
 
 -- * Catamorphism
-
 
 -- |Consumes a value of type 'NS'
 cataNS :: (forall x xs . f x  -> r (x ': xs))

--- a/src/Generics/MRSOP/Opaque.hs
+++ b/src/Generics/MRSOP/Opaque.hs
@@ -14,6 +14,7 @@
 module Generics.MRSOP.Opaque where
 
 import Data.Type.Equality
+import Generics.MRSOP.Util
 
 -- * Opaque Types
 --
@@ -48,7 +49,7 @@ data Singl (kon :: Kon) :: * where
   SChar    :: Char    -> Singl 'KChar
   SString  :: String  -> Singl 'KString
 
-deriving instance Eq   (Singl k)
+deriving instance Eq (Singl k)
 
 instance Show (Singl k) where
  show (SInt      a) = show a 
@@ -62,6 +63,12 @@ instance Show (Singl k) where
 -- |Equality over singletons
 eqSingl :: Singl k -> Singl k -> Bool
 eqSingl = (==)
+
+instance EqHO Singl where
+  eqHO = eqSingl
+
+instance ShowHO Singl where
+  showHO = show
 
 instance TestEquality Singl where
   testEquality (SInt _) (SInt _)         = Just Refl

--- a/src/Generics/MRSOP/Util.hs
+++ b/src/Generics/MRSOP/Util.hs
@@ -36,7 +36,7 @@ module Generics.MRSOP.Util
   , Lkup , Idx , El(..) , getElSNat , into
 
     -- * Higher-order Eq and Show
-  , EqHO , ShowHO
+  , EqHO(..) , ShowHO(..)
   ) where
 
 import Data.Proxy


### PR DESCRIPTION
* brought back `EqHO` and `ShowHO` without the `-XQuantifiedConstraints` trickery; this simplifies
the handling of constraints everywhere. 

closes #58 

