### PR TITLE
Support for GHC >= 8.8

### DIFF
--- a/generics-mrsop.cabal
+++ b/generics-mrsop.cabal
@@ -7,7 +7,7 @@ cabal-version: 1.12
 -- hash: 70539c4715fe3541bae476f1a318b450ec2afab772fca5e4d87aa41b9eab122a
 
 name:           generics-mrsop
-version:        2.3.0
+version:        2.3.1
 synopsis:       Generic Programming with Mutually Recursive Sums of Products.
 description:    A library that supports generic programming for mutually recursive families in the sum-of-products style. . A couple usage examples can be found under "Generics.MRSOP.Examples" .
 category:       Generics

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:        generics-mrsop
-version:     2.3.0
+version:     2.3.1
 synopsis:    Generic Programming with Mutually Recursive Sums of Products.
 description:
   A library that supports generic programming for mutually

--- a/stack-18.yaml
+++ b/stack-18.yaml
@@ -1,0 +1,6 @@
+resolver: lts-18.28
+packages:
+- .
+
+
+

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-14.1
+resolver: lts-19.0
 packages:
 - .
 


### PR DESCRIPTION
This PR does two different things:
1. Conditionally imports `MonadFail`, and changes one implementation to refer to it. Since GHC 8.8.1, any usage of `fail` introduces a `MonadFail` constraint, instead of just `Monad`.
2. Uses the updated version of `TyVarBndr` with a flag in GHC 9.0 on.

In addition, the `stack.yaml` files has been updated to the latest version, and one for 8.x has been kept as `stack-18.yaml`.